### PR TITLE
Fix exception in gym webhook if name is missing

### DIFF
--- a/monocle/notification.py
+++ b/monocle/notification.py
@@ -1056,10 +1056,10 @@ class Notifier:
                 }
             }
             self.log.info("Notifying gym Name = {}, team = {}", fort["name"], fort["team"])
-        result = await self.wh_send(SessionManager.get(), data)
-        self.last_notification = monotonic()
-        self.sent += 1
-        return result
+            result = await self.wh_send(SessionManager.get(), data)
+            self.last_notification = monotonic()
+            self.sent += 1
+            return result
 
     async def webhook_raid(self, raid, fort):
         if not WEBHOOK:


### PR DESCRIPTION
Gyms with missing names result in:
```
[   ERROR][eventloop] {'message': 'Task exception was never retrieved', 'exception': UnboundLocalError("local variable 'data' referenced before assignment",), 'future': <Task finished coro=<Notifier.webhook_gym() done, defined at /home/pogo/Monocle/monocle/notification.py:1041> exception=UnboundLocalError("local variable 'data' referenced before assignment",)>}
```

as data is only set if a name is available, but then still tries to send it.