### PR TITLE
Add deployment_time, owner_level, improve KEEP_GYM_HISTORY and more

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -130,8 +130,8 @@ SKIP_SPAWN = 1500      # don't even try to find a worker for a spawn if the spaw
 # Monocle defaults to scan.log plus 4 for a total of 5
 #LOGGED_FILES = 4
 
-# Allows you to specify size for log files to keep 
-# Monocle defaults to scan.log 
+# Allows you to specify size for log files to keep
+# Monocle defaults to scan.log
 #LOGGED_SIZE = 500000
 
 # Limit the number of simultaneous logins to this many at a time.
@@ -173,7 +173,7 @@ SEARCH_SLEEP = 2.5
 #
 #GO_HASH_KEY = 'YOURGOHASHKEY' # edit with your Gohash key
 #
-### Gohash endpoint 
+### Gohash endpoint
 #GOHASH_ENDPOINT="http://hash.gomanager.biz"
 
 # Skip PokéStop spinning and egg incubation if your request rate is too high
@@ -210,7 +210,7 @@ SPIN_COOLDOWN = 300    # spin only one PokéStop every n seconds (default 300)
 ## Gyms
 
 ### Toggles scanning for gym names.
-#GYM_NAMES = True 
+#GYM_NAMES = True
 
 ### Toggles scanning gyms for gym_defenders.
 ### Set this to False if you want to call GYM_GET_INFO RPC only for gym names.
@@ -232,7 +232,7 @@ ITEM_LIMITS = {
     202:  5,  # Max Revive
     301:  5,  # Lucky Egg
     401:  5,  # Incense
-    501:  5,  # Lure Module 
+    501:  5,  # Lure Module
     701:  5,  # Razz Berry
     702:  5,  # Bluk Berry
     703:  5,  # Nanab Berry
@@ -262,7 +262,7 @@ LOGIN_TIMEOUT = 2.5
 # Set to True to kill the scanner when a newer version is forced
 #FORCED_KILL = False
 
-### Exclude these Pokémon from the map by default (only visible in trash layer) 
+### Exclude these Pokémon from the map by default (only visible in trash layer)
 ### DB insert is not affected. The will still be inserted to DB as normal. See NO_DB_INSERT_IDS config below.
 TRASH_IDS = (
     16, 19, 21, 29, 32, 41, 46, 48, 50, 52, 56, 74, 77, 96, 111, 133,
@@ -311,7 +311,7 @@ MAP_WORKERS = True
 LAST_MIGRATION = 1481932800  # Dec. 17th, 2016
 
 # Treat a spawn point's expiration time as unknown if nothing is seen at it on more than x consecutive visits
-#FAILURES_ALLOWED = 3 
+#FAILURES_ALLOWED = 3
 
 ## Map data provider and appearance, previews available at:
 ## https://leaflet-extras.github.io/leaflet-providers/preview/
@@ -735,12 +735,12 @@ MINIMUM_SCORE = 0.4  # the required score after FULL_TIME seconds have passed
 
 ####
 ### PgScout (Credit to Avatar690)
-## MUST MATCH YOUR PGSCOUT CONFIG.JSON.  Will encounter based on ENCOUNTER_IDs above.  
+## MUST MATCH YOUR PGSCOUT CONFIG.JSON.  Will encounter based on ENCOUNTER_IDs above.
 ## If encounter fails, worker.py will attempt to encounter with the running acount (if lv > 30)
 ## If it fails, sighting will be saved without additional encounter info.
 
 ### Enter in your address for PGSCOUT hook endpoint including hostname, port (if any) and path.
-### If set to a url, PGSCOUT will be used. If None, normal Monocle encounter will be used. 
+### If set to a url, PGSCOUT will be used. If None, normal Monocle encounter will be used.
 #
 #PGSCOUT_ENDPOINT = None
 #
@@ -754,7 +754,7 @@ MINIMUM_SCORE = 0.4  # the required score after FULL_TIME seconds have passed
 ## Going too high will certainly guarantee a response from a Scout but will lead to greater inefficiency
 ## and instability for Monocle
 #
-#PGSCOUT_TIMEOUT = 40 
+#PGSCOUT_TIMEOUT = 40
 #
 
 
@@ -766,7 +766,7 @@ MINIMUM_SCORE = 0.4  # the required score after FULL_TIME seconds have passed
 #
 ### If True, new sightings inserted. Else, existing sighting for the same spawnpoint will be updated (if found).
 ### Default is True
-#KEEP_SPAWNPOINT_HISTORY = True 
+#KEEP_SPAWNPOINT_HISTORY = True
 
 
 ### Cleanup
@@ -777,8 +777,8 @@ MINIMUM_SCORE = 0.4  # the required score after FULL_TIME seconds have passed
 # CLEANUP_RAIDS_OLDER_THAN_X_HR = 6.0
 # CLEANUP_SIGHTINGS_OLDER_THAN_X_HR = 6.0
 # CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR = 6.0
+# CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR = 12.0
 # CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR = 24.0
 
 ### Discord webhook url for sending scan log messages
 #SCAN_LOG_WEBHOOK = None
-

--- a/migrations/versions/84045eaaeed7_imrpove_gymhistory_and_more.py
+++ b/migrations/versions/84045eaaeed7_imrpove_gymhistory_and_more.py
@@ -1,0 +1,58 @@
+"""add deployment_time, cp_now, trainer_level, total_cp, indexes and gym_history_defenders
+
+Revision ID: 84045eaaeed7
+Revises: 5afaec120529
+Create Date: 2018-02-18 15:29:22.251893
+
+"""
+from alembic import op
+import sqlalchemy as sa
+import sys
+from pathlib import Path
+monocle_dir = str(Path(__file__).resolve().parents[2])
+if monocle_dir not in sys.path:
+    sys.path.append(monocle_dir)
+from monocle import db as db
+
+# revision identifiers, used by Alembic.
+revision = '84045eaaeed7'
+down_revision = '5afaec120529'
+branch_labels = None
+depends_on = None
+
+def upgrade():
+    op.create_index('ix_sightings_updated', 'sightings', ['updated'], unique=False)
+    op.create_index('ix_sightings_spawn_id', 'sightings', ['spawn_id'], unique=False)
+    op.create_index('ix_sightings_pokemon_id', 'sightings', ['pokemon_id'], unique=False)
+    op.create_index('ix_sightings_lat_lon', 'sightings', ['lat', 'lon'], unique=False)
+    op.create_unique_constraint('external_id_unique', 'gym_defenders', ['external_id'])
+    op.add_column('gym_defenders', sa.Column('deployment_time', sa.Integer(), nullable=True))
+    op.add_column('gym_defenders', sa.Column('cp_now', sa.Integer(), nullable=True))
+    op.add_column('gym_defenders', sa.Column('owner_level', sa.SmallInteger(), nullable=True))
+    op.add_column('fort_sightings', sa.Column('total_cp', sa.SmallInteger(), nullable=True))
+    op.alter_column('gym_defenders', 'fort_id', existing_type=sa.Integer(), existing_nullable=False, nullable=True)
+    op.create_table('gym_history_defenders',
+       sa.Column('id', db.PRIMARY_HUGE_TYPE, nullable=False),
+       sa.Column('fort_id', sa.Integer(), nullable=False),
+       sa.Column('defender_id', db.UNSIGNED_HUGE_TYPE, nullable=True),
+       sa.Column('date', sa.Integer(), nullable=False),
+       sa.Column('created', sa.Integer(), nullable=False),
+       sa.Column('cp', sa.SmallInteger(), nullable=False),
+       sa.PrimaryKeyConstraint('id'),
+       sa.ForeignKeyConstraint(['fort_id'], ['forts.id'], onupdate='CASCADE', ondelete='CASCADE'),
+       sa.ForeignKeyConstraint(['defender_id'], ['gym_defenders.external_id'], onupdate='CASCADE', ondelete='CASCADE'),
+       sa.UniqueConstraint('fort_id', 'defender_id', 'date', name='fort_id_defender_id_date')
+    )
+
+def downgrade():
+    op.drop_index('ix_sightings_lat_lon', table_name='sightings')
+    op.drop_index('ix_sightings_pokemon_id', table_name='sightings')
+    op.drop_index('ix_sightings_spawn_id', table_name='sightings')
+    op.drop_index('ix_sightings_updated', table_name='sightings')
+    op.drop_constraint('external_id_unique', 'gym_defenders')
+    op.drop_column('gym_defenders', 'deployment_time')
+    op.drop_column('gym_defenders', 'cp_now')
+    op.drop_column('gym_defenders', 'owner_level')
+    op.drop_column('fort_sightings', 'total_cp')
+    op.alter_column('gym_defenders', 'fort_id', existing_nullable=True, nullable=False)
+    op.drop_table('gym_history_defenders')

--- a/monocle/cleanup.py
+++ b/monocle/cleanup.py
@@ -69,12 +69,12 @@ def light():
     if is_service_alive():
         if conf.CLEANUP_RAIDS_OLDER_THAN_X_HR > 0:
             cleanup_with_temp_table("raids", now - (conf.CLEANUP_RAIDS_OLDER_THAN_X_HR * 3600), time_col="time_spawn")
+        if conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR > 0 or conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR > 0:
+            cleanup_with_temp_table("gym_history_defenders", now - (min(conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR, conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR) * 3600), time_col="created")
         if conf.CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR > 0:
             cleanup_with_temp_table("fort_sightings", now - (conf.CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR * 3600))
         if conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR > 0 :
             cleanup_with_temp_table("gym_defenders", now - (conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR * 3600), time_col="created")
-        if conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR > 0 or conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR > 0:
-            cleanup_with_temp_table("gym_history_defenders", now - (min(conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR, conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR) * 3600), time_col="created")
         if conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR > 0:
             cleanup_with_temp_table("mystery_sightings", now - (conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR * 3600), time_col="first_seen")
         if conf.CLEANUP_SIGHTINGS_OLDER_THAN_X_HR > 0:

--- a/monocle/cleanup.py
+++ b/monocle/cleanup.py
@@ -8,7 +8,7 @@ from .shared import get_logger
 from . import sanitized as conf
 
 log = get_logger(__name__)
-    
+
 db_dialect = None
 
 if isinstance(_engine.dialect, MySQLDialect_mysqldb):
@@ -38,7 +38,7 @@ def cleanup_with_temp_table(table, time, limit=conf.CLEANUP_LIMIT, time_col="upd
           SELECT t.id
           FROM {} t
           WHERE t.{} IS NULL OR t.{} < :time
-          LIMIT :limit 
+          LIMIT :limit
         )""".format(table, table, time_col, time_col), {
             'time': time,
             'limit': limit,
@@ -56,10 +56,10 @@ def is_service_alive():
 
     with session_scope(autoflush=True) as session:
         last_updated = session.query(func.max(FortSighting.updated)).first()[0]
-        last_updated = last_updated if last_updated else 0 
+        last_updated = last_updated if last_updated else 0
         if last_updated > thirty_min_ago:
-            return True 
-    return False 
+            return True
+    return False
 
 
 def light():
@@ -71,6 +71,10 @@ def light():
             cleanup_with_temp_table("raids", now - (conf.CLEANUP_RAIDS_OLDER_THAN_X_HR * 3600), time_col="time_spawn")
         if conf.CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR > 0:
             cleanup_with_temp_table("fort_sightings", now - (conf.CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR * 3600))
+        if conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR > 0 :
+            cleanup_with_temp_table("gym_defenders", now - (conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR * 3600), time_col="created")
+        if conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR > 0 or conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR > 0:
+            cleanup_with_temp_table("gym_history_defenders", now - (min(conf.CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR, conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR) * 3600), time_col="created")
         if conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR > 0:
             cleanup_with_temp_table("mystery_sightings", now - (conf.CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR * 3600), time_col="first_seen")
         if conf.CLEANUP_SIGHTINGS_OLDER_THAN_X_HR > 0:

--- a/monocle/sanitized.py
+++ b/monocle/sanitized.py
@@ -40,6 +40,7 @@ _valid_types = {
     'CLEANUP_SIGHTINGS_OLDER_THAN_X_HR': Number,
     'CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR': Number,
     'CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR': Number,
+    'CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR': Number,
     'COMPLETE_TUTORIAL': bool,
     'COROUTINES_LIMIT': int,
     'DB': dict,
@@ -191,7 +192,7 @@ _valid_types = {
     'WEBHOOKS': set_sequence,
     'WEATHER_STATUS': dict,
     'WEBHOOK_GYM_MAPPING': dict,
-    'WEBHOOK_RAID_MAPPING': dict, 
+    'WEBHOOK_RAID_MAPPING': dict,
 }
 
 _defaults = {
@@ -216,6 +217,7 @@ _defaults = {
     'CLEANUP_SIGHTINGS_OLDER_THAN_X_HR': 4.0,
     'CLEANUP_FORT_SIGHTINGS_OLDER_THAN_X_HR': 4.0,
     'CLEANUP_MYSTERY_SIGHTINGS_OLDER_THAN_X_HR': 48.0,
+    'CLEANUP_GYM_DEFENDERS_OLDER_THAN_X_HR': 12.0,
     'COMPLETE_TUTORIAL': False,
     'CONTROL_SOCKS': None,
     'COROUTINES_LIMIT': worker_count,

--- a/monocle/worker.py
+++ b/monocle/worker.py
@@ -65,7 +65,7 @@ class Worker:
     download_hash = ''
     scan_delay = conf.SCAN_DELAY if conf.SCAN_DELAY >= 10 else 10
     g = {'seen': 0, 'captchas': 0}
-    more_point_cell_cache = TtlCache(ttl=300) 
+    more_point_cell_cache = TtlCache(ttl=300)
     has_raiders = (conf.RAIDERS_PER_GYM and conf.RAIDERS_PER_GYM > 0)
     scan_gym = conf.GYM_NAMES or conf.GYM_DEFENDERS
     passive_scan_gym = (scan_gym and not has_raiders)
@@ -113,7 +113,7 @@ class Worker:
         self.captcha_queue = captcha_queue
         self.worker_dict = worker_dict
         self.account_dict = account_dict
-        
+
         # account information
         try:
             self.account = self.account_queue.get_nowait()
@@ -146,7 +146,7 @@ class Worker:
             self.player_level = self.account.get('level', 0)
             self.initialize_api()
         else:
-            self.last_request = 0 
+            self.last_request = 0
             self.items = {}
             self.bag_items = 0
             self.inventory_timestamp = 0
@@ -174,7 +174,7 @@ class Worker:
         self.last_encounter = int(round(time() * 1000))
 
     def needs_sleep(self):
-        return True 
+        return True
 
     def min_level(self):
         return 0
@@ -965,7 +965,7 @@ class Worker:
         if conf.ITEM_LIMITS and self.bag_items >= self.item_capacity:
             await self.clean_bag()
 
-            
+
         if map_objects.client_weather:
             for w in map_objects.client_weather:
                 weather = Weather.normalize_weather(w, map_objects.time_of_day)
@@ -1007,17 +1007,17 @@ class Worker:
                 if not encounter_id:
                     if self.should_skip_sighting(normalized, SIGHTING_CACHE):
                         continue
-                
+
                 # Check against insert list
                 sp_discovered = (normalized.get('despawn') is not None)
-                is_in_insert_blacklist = (conf.NO_DB_INSERT_IDS is not None and 
+                is_in_insert_blacklist = (conf.NO_DB_INSERT_IDS is not None and
                         normalized['pokemon_id'] in conf.NO_DB_INSERT_IDS)
                 skip_insert = (sp_discovered and is_in_insert_blacklist)
 
                 self.log.debug('Pokemon: {}, sp: {}, sp_discovered: {}, in_blacklist: {}, skip_insert: {}',
                         normalized['pokemon_id'], spawn_id, sp_discovered, is_in_insert_blacklist, skip_insert)
 
-                # Do not insert to db for this pokemon 
+                # Do not insert to db for this pokemon
                 if skip_insert:
                     db_proc.count += 1
                     continue
@@ -1026,7 +1026,7 @@ class Worker:
                         (not self.player_level or self.player_level < 30))
                 should_notify = self.should_notify(normalized)
                 should_encounter = (sp_discovered and self.should_encounter(normalized, should_notify=should_notify))
-                    
+
                 if encounter_id:
                     cache = self.overseer.ENCOUNTER_CACHE if should_encounter else SIGHTING_CACHE
                     if self.should_skip_sighting(normalized, cache):
@@ -1231,7 +1231,7 @@ class Worker:
 
         if gmo_success:
             if not seen_encounter:
-                return -1 
+                return -1
 
             if not seen_gym:
                 if forts_seen > 0:
@@ -1303,7 +1303,7 @@ class Worker:
 
         await self.update_accounts_dict()
         self.handle = LOOP.call_later(60, self.unset_code)
-        return 1 
+        return 1
 
     def should_skip_sighting(self, sighting, cache):
         # Check if already marked for save as sighting
@@ -1408,16 +1408,16 @@ class Worker:
                 name, distance, self.speed, UNIT_STRING)
 
         self.error_code = '!'
-        
-        return gym 
+
+        return gym
 
     async def spin_pokestop(self, pokestop):
         self.error_code = '$'
         pokestop_location = pokestop.latitude, pokestop.longitude
-        
+
         # randomize location up to ~1.5 meters
         self.simulate_jitter(amount=0.00001)
-        
+
         distance = get_distance(self.location, pokestop_location)
         # permitted interaction distance - 4 (for some jitter leeway)
         # estimation of spinning speed limit
@@ -1425,7 +1425,7 @@ class Worker:
             self.error_code = '!'
             return False
 
-        #adding a short sleep period increases spinning success 
+        #adding a short sleep period increases spinning success
         await self.random_sleep(0.8, 1.8)
 
         request = self.api.create_request()
@@ -1731,7 +1731,7 @@ class Worker:
             self.account['expiry'] = self.api.auth_provider._access_token_expiry
         except AttributeError:
             pass
-        
+
         ACCOUNTS = self.account_dict
         if 'remove' in self.account and self.account['remove']:
             if self.username in ACCOUNTS:
@@ -1777,13 +1777,13 @@ class Worker:
         else:
             self.account['banned'] = True
             log_message = "Hibernating {} due to ban.".format(self.username, self.player_level)
-            
-        self.log.warning(log_message)            
+
+        self.log.warning(log_message)
         LOOP.create_task(self.notifier.hibernate_webhook(self.username, self.player_level, log_message))
-        
+
         await self.update_accounts_dict()
         self.username = None
-        self.account = None      
+        self.account = None
         await self.new_account(after_remove=True)
 
     async def bench_account(self):
@@ -1881,7 +1881,7 @@ class Worker:
 
     def prioritize_forts(self, map_cell_forts):
 
-        # Filter gyms that are nearby 
+        # Filter gyms that are nearby
         forts = [ x for x in map_cell_forts if x.type == 0 and self.within_distance(x, max_distance=445)]
 
         raids_to_check = [ x for x in forts if x.HasField("raid_info") and (x not in RAID_CACHE)]
@@ -2015,7 +2015,8 @@ class Worker:
             'owner_name': pokemon.owner_name,
             'owner_level': trainer.level,
             'nickname': pokemon.nickname,
-            'cp': pokemon.cp,
+            'cp_now': raw.motivated_pokemon.cp_now,
+            'cp': raw.motivated_pokemon.cp_when_deployed,
             'stamina': pokemon.stamina,
             'stamina_max': pokemon.stamina_max,
             'atk_iv': pokemon.individual_attack,
@@ -2026,6 +2027,7 @@ class Worker:
             'battles_attacked': pokemon.battles_attacked,
             'battles_defended': pokemon.battles_defended,
             'num_upgrades': 0,
+            'deployment_time': int(round(time() - raw.deployment_totals.deployment_duration_ms / 1000)),
         }
 
         if hasattr(pokemon, 'num_upgrades'):
@@ -2095,4 +2097,3 @@ class CaptchaSolveException(Exception):
 class OverseerNotRunningException(Exception):
     """Raised when overseer is no longer running."""
     pass
-


### PR DESCRIPTION
This PR contains multiple improvements:

1. Add total_cp to fort_sightings
2. Add deployment_time and owner_level to the gym_defenders
3. Add cp_now to the gym_defenders
   - cp_now is the current defenders cp
   - cp is the max cp
4. Imrpove KEEP_GYM_HISTORY (make KEEP_GYM_HISTORY a prober gym history)
   - also story defender history
   - keep gym_defenders even if they aren't in a gym any more
   - fix a but that caused a unique constraint to fail
5. Add indexes to sightings to significantly improve performance on larger databases